### PR TITLE
fix: Waylay Saturate was catalytic all along

### DIFF
--- a/packages/valorant_agents/lib/src/models/agent.dart
+++ b/packages/valorant_agents/lib/src/models/agent.dart
@@ -726,8 +726,8 @@ class Agent extends Equatable implements Comparable<Agent> {
   );
   static const waylay = Agent(
     name: 'Waylay',
-    aggro: 6,
-    control: 3,
+    aggro: 7,
+    control: 2,
     midrange: 1,
     role: Role.duelist,
     abilityOne: AbilityOne(
@@ -744,9 +744,9 @@ class Agent extends Equatable implements Comparable<Agent> {
     ),
     abilityThree: AbilityThree(
       name: 'Saturate',
-      aggro: 1,
-      control: 2,
-      reasons: ['Short Range', 'Non-catalytic Duel Facilitation', 'Stall'],
+      aggro: 2,
+      control: 1,
+      reasons: ['Short Range', 'Self-capitalizable Catalytic Util', 'Stall'],
     ),
     ultimateAbility: UltimateAbility(
       name: 'Convergent Paths',

--- a/packages/valorant_agents/lib/src/parser/agents.dart
+++ b/packages/valorant_agents/lib/src/parser/agents.dart
@@ -3,8 +3,8 @@ import 'package:valorant_agents/valorant_agents.dart';
 // Waylay SD2 score before Saturate changed from INSTANT to EQUIP in Patch 12.06
 const _waylayPre12_06 = Agent(
   name: 'Waylay',
-  aggro: 7,
-  control: 2,
+  aggro: 8,
+  control: 1,
   midrange: 1,
   role: Role.duelist,
   abilityOne: AbilityOne(
@@ -21,9 +21,8 @@ const _waylayPre12_06 = Agent(
   ),
   abilityThree: AbilityThree(
     name: 'Saturate',
-    aggro: 2,
-    control: 1,
-    reasons: ['Fast Cast', 'Short Range', 'Non-catalytic Duel Facilitation'],
+    aggro: 3,
+    reasons: ['Fast Cast', 'Short Range', 'Self-capitalizable Catalytic Util'],
   ),
   ultimateAbility: UltimateAbility(
     name: 'Convergent Paths',


### PR DESCRIPTION
## Status

**READY**

## Description

Even though, originally Waylay's Saturate ability was theoretically categorized as "Non-Catalytic Duel Facilitation (C)" since first bullet is unaffected, but in practice it is effectively "Self-capitalizable Catalytic Util (A)" because of the advantage generated by putting pressure on opponent to hit the first shot. For said reasons, Waylay's current and pre patch 12.06 nerf SD2 scores are adjusted accordingly.

Side Note: There's some case for categorizing Waylay's Saturate and Deadlock's Gravnet as "Pseudo-Catalytic Util (M)", but for simplicity Saturate is categorized as Catalytic (A) and Gravnet as Non-catalytic (C). -AnderzzTV (paraphrased)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
