### PR TITLE
chore: upgrade to Flutter 3.48.0-0.1.pre + pre-fire the material_ui migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related
@@ -23,12 +25,11 @@ migrate_working_dir/
 **/doc/api/
 **/ios/Flutter/.last_build_id
 .dart_tool/
-.flutter-plugins
 .flutter-plugins-dependencies
 .pub-cache/
 .pub/
 /build/
-pubspec_overrides.yaml
+/coverage/
 
 # Symbolication related
 app.*.symbols
@@ -41,5 +42,9 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-# Experimental Widget-Previews related
+# Widget Preview related
+.widget_preview/
+
+# Additional Ignores
+pubspec_overrides.yaml
 /lib/preview*.dart

--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "034409942b77d054d9e3914d7ef1183485d87f26"
+  revision: "ceb9a865625239789d86b31be0a8d04e4c5a5084"
   channel: "beta"
 
 project_type: app
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 034409942b77d054d9e3914d7ef1183485d87f26
-      base_revision: 034409942b77d054d9e3914d7ef1183485d87f26
+      create_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
+      base_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
     - platform: android
-      create_revision: 034409942b77d054d9e3914d7ef1183485d87f26
-      base_revision: 034409942b77d054d9e3914d7ef1183485d87f26
+      create_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
+      base_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
     - platform: ios
-      create_revision: 034409942b77d054d9e3914d7ef1183485d87f26
-      base_revision: 034409942b77d054d9e3914d7ef1183485d87f26
+      create_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
+      base_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
     - platform: linux
-      create_revision: 034409942b77d054d9e3914d7ef1183485d87f26
-      base_revision: 034409942b77d054d9e3914d7ef1183485d87f26
+      create_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
+      base_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
     - platform: macos
-      create_revision: 034409942b77d054d9e3914d7ef1183485d87f26
-      base_revision: 034409942b77d054d9e3914d7ef1183485d87f26
+      create_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
+      base_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
     - platform: web
-      create_revision: 034409942b77d054d9e3914d7ef1183485d87f26
-      base_revision: 034409942b77d054d9e3914d7ef1183485d87f26
+      create_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
+      base_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
     - platform: windows
-      create_revision: 034409942b77d054d9e3914d7ef1183485d87f26
-      base_revision: 034409942b77d054d9e3914d7ef1183485d87f26
+      create_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
+      base_revision: ceb9a865625239789d86b31be0a8d04e4c5a5084
 
   # User provided section
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-all.zip

--- a/lib/add_agents/view/add_agents_page.dart
+++ b/lib/add_agents/view/add_agents_page.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:formz/formz.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/add_agents/add_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/add_agents/widgets/copy_json_button.dart
+++ b/lib/add_agents/widgets/copy_json_button.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/add_agents/widgets/import_json_button.dart
+++ b/lib/add_agents/widgets/import_json_button.dart
@@ -1,6 +1,6 @@
 import 'package:file_selector/file_selector.dart';
-import 'package:flutter/material.dart';
 import 'package:formz_inputs/formz_inputs.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/lib/add_agents/widgets/roster_name_form_field.dart
+++ b/lib/add_agents/widgets/roster_name_form_field.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:formz_inputs/formz_inputs.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/l10n/l10n.dart';
 
 class RosterNameFormField extends StatelessWidget {

--- a/lib/add_matches/view/add_matches_page.dart
+++ b/lib/add_matches/view/add_matches_page.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:formz/formz.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/add_matches/add_matches.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/add_matches/widgets/collection_name_form_field.dart
+++ b/lib/add_matches/widgets/collection_name_form_field.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:formz_inputs/formz_inputs.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/l10n/l10n.dart';
 
 class CollectionNameFormField extends StatelessWidget {

--- a/lib/add_matches/widgets/import_matches_csv.dart
+++ b/lib/add_matches/widgets/import_matches_csv.dart
@@ -1,6 +1,6 @@
 import 'package:file_selector/file_selector.dart';
-import 'package:flutter/material.dart';
 import 'package:formz_inputs/formz_inputs.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/lib/agent_combo_matches/view/agent_combo_matches_page.dart
+++ b/lib/agent_combo_matches/view/agent_combo_matches_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/agent_combo_matches/agent_combo_matches.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/agents/view/agents_page.dart
+++ b/lib/agents/view/agents_page.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/agents/agents.dart' hide AgentsTriangleView;
 import 'package:vsdat/app_router/routes.dart';

--- a/lib/agents_overview/provider/agents_overview_provider.g.dart
+++ b/lib/agents_overview/provider/agents_overview_provider.g.dart
@@ -42,7 +42,7 @@ final class AgentsOverviewNotifierProvider
 }
 
 String _$agentsOverviewNotifierHash() =>
-    r'317bcdfa0a9dbf115db4e81757e3eba9b51412af';
+    r'a0cf03599f2be96bca5f2f0bba459791f7ca57fa';
 
 abstract class _$AgentsOverviewNotifier extends $Notifier<AgentsOverviewState> {
   AgentsOverviewState build();

--- a/lib/agents_overview/view/agents_overview_page.dart
+++ b/lib/agents_overview/view/agents_overview_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/agents_overview/agents_overview.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/l10n/l10n.dart';

--- a/lib/agents_overview/widgets/agents_list_view.dart
+++ b/lib/agents_overview/widgets/agents_list_view.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/agents_overview/agents_overview.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/agents_stats/view/agents_stats_page.dart
+++ b/lib/agents_stats/view/agents_stats_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/agents/agents.dart';
 import 'package:vsdat/agents_stats/widgets/agents_grid_view.dart';
 

--- a/lib/agents_stats/widgets/agents_grid_view.dart
+++ b/lib/agents_stats/widgets/agents_grid_view.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/agents_overview/agents_overview.dart';
 import 'package:vsdat/app/app.dart';
 import 'package:vsdat/app/widgets/widgets.dart';

--- a/lib/app/widgets/view_source_button.dart
+++ b/lib/app/widgets/view_source_button.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/link.dart';
 import 'package:vsdat/gen/gen.dart';
 import 'package:vsdat/l10n/l10n.dart';

--- a/lib/app_router/app_router.dart
+++ b/lib/app_router/app_router.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vsdat/agents_overview/agents_overview.dart';
 import 'package:vsdat/app_router/routes.dart';

--- a/lib/app_router/pages.dart
+++ b/lib/app_router/pages.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ModalBottomSheetPage<T> extends Page<T> {
   const ModalBottomSheetPage({

--- a/lib/app_router/routes.dart
+++ b/lib/app_router/routes.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/add_agents/view/add_agents_page.dart';
 import 'package:vsdat/add_matches/view/add_matches_page.dart';

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -1,9 +1,9 @@
 import 'dart:developer';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 
 final _logger = Logger('val_sd_analyzer');

--- a/lib/combo_synergies/view/combo_synergies_page.dart
+++ b/lib/combo_synergies/view/combo_synergies_page.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:two_dimensional_scrollables/two_dimensional_scrollables.dart';
 import 'package:url_launcher/link.dart';
 import 'package:vsdat/app_router/routes.dart';

--- a/lib/combo_synergies/widgets/combo_agent_indicator.dart
+++ b/lib/combo_synergies/widgets/combo_agent_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/combo_synergies/combo_synergies.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/lib/combo_synergies/widgets/combo_synergies_filter_drawer.dart
+++ b/lib/combo_synergies/widgets/combo_synergies_filter_drawer.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/combo_synergies/combo_synergies.dart';
 import 'package:vsdat/l10n/l10n.dart';

--- a/lib/combo_synergies/widgets/hovered_synergy_stat_card.dart
+++ b/lib/combo_synergies/widgets/hovered_synergy_stat_card.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/combo_synergies/combo_synergies.dart';
 

--- a/lib/combo_synergies/widgets/sortable_table_header.dart
+++ b/lib/combo_synergies/widgets/sortable_table_header.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class SortableTableHeader extends StatelessWidget {
   const SortableTableHeader({

--- a/lib/matches/view/matches_page.dart
+++ b/lib/matches/view/matches_page.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/matches/matches.dart';

--- a/lib/matches/widgets/auto_filter_button.dart
+++ b/lib/matches/widgets/auto_filter_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/lib/matches/widgets/matches_filter_drawer.dart
+++ b/lib/matches/widgets/matches_filter_drawer.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/matches/matches.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/matches/widgets/matches_hover_info_card.dart
+++ b/lib/matches/widgets/matches_hover_info_card.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/matches/matches.dart';

--- a/lib/matches/widgets/matches_triangle.dart
+++ b/lib/matches/widgets/matches_triangle.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/matches/matches.dart';

--- a/lib/matches/widgets/min_matches_input.dart
+++ b/lib/matches/widgets/min_matches_input.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/matches/provider/matches_provider.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/lib/matches_overview/view/matches_overview_page.dart
+++ b/lib/matches_overview/view/matches_overview_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/agents_overview/agents_overview.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/l10n/l10n.dart';

--- a/lib/matches_overview/widgets/matches_collection_tile.dart
+++ b/lib/matches_overview/widgets/matches_collection_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/matches_overview/matches_overview.dart';

--- a/lib/matches_stats/view/matches_stats_page.dart
+++ b/lib/matches_stats/view/matches_stats_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/matches_stats/matches_stats.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/matches_stats/widgets/matches_stat_card.dart
+++ b/lib/matches_stats/widgets/matches_stat_card.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/l10n/l10n.dart';

--- a/lib/matches_stats/widgets/matches_stat_list_view.dart
+++ b/lib/matches_stats/widgets/matches_stat_list_view.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/matches_stats/matches_stats.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/lib/matches_stats/widgets/non_transitive_interaction_card.dart
+++ b/lib/matches_stats/widgets/non_transitive_interaction_card.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/matches_stats/widgets/widgets.dart';

--- a/lib/matches_stats/widgets/style_type_matchup_stat_card.dart
+++ b/lib/matches_stats/widgets/style_type_matchup_stat_card.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/matches_stats/widgets/widgets.dart';

--- a/lib/styled_matches/view/styled_matches_page.dart
+++ b/lib/styled_matches/view/styled_matches_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/l10n/l10n.dart';

--- a/lib/styled_matches/widgets/styled_matches_filter_drawer.dart
+++ b/lib/styled_matches/widgets/styled_matches_filter_drawer.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/matches/matches.dart';

--- a/lib/styled_matches/widgets/styled_matches_hovered_card.dart
+++ b/lib/styled_matches/widgets/styled_matches_hovered_card.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/styled_matches/widgets/styled_matches_triangle.dart
+++ b/lib/styled_matches/widgets/styled_matches_triangle.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/app_router/routes.dart';

--- a/lib/styled_matches/widgets/styled_style_hovered_card.dart
+++ b/lib/styled_matches/widgets/styled_style_hovered_card.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/lib/styled_matches_list/view/styled_matches_list_page.dart
+++ b/lib/styled_matches_list/view/styled_matches_list_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/styled_matches_list/styled_matches_list.dart';

--- a/lib/styled_matches_list/widgets/styled_matches_custom_list.dart
+++ b/lib/styled_matches_list/widgets/styled_matches_custom_list.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:matches_repository/matches_repository.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/styled_matches_list/styled_matches_list.dart';

--- a/lib/styled_matchup_list/view/styled_matchup_list_page.dart
+++ b/lib/styled_matchup_list/view/styled_matchup_list_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/styled_matchup_list/styled_matchup_list.dart';

--- a/lib/team_comps/provider/team_comps_provider.g.dart
+++ b/lib/team_comps/provider/team_comps_provider.g.dart
@@ -300,7 +300,7 @@ final class CompositionsProvider
   }
 }
 
-String _$compositionsHash() => r'4f96d3d79e887685b30d17a50826a862e573d458';
+String _$compositionsHash() => r'd272973c4ac44a1e2eb1c1db1c0cf7242ab3feee';
 
 final class CompositionsFamily extends $Family
     with

--- a/lib/team_comps/view/team_comps_page.dart
+++ b/lib/team_comps/view/team_comps_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat/agents_overview/agents_overview.dart';
 import 'package:vsdat/app_router/routes.dart';
 import 'package:vsdat/l10n/l10n.dart';

--- a/lib/team_comps/widgets/team_comps_filter.dart
+++ b/lib/team_comps/widgets/team_comps_filter.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/agents/agents.dart';
 import 'package:vsdat/app_router/routes.dart';

--- a/lib/team_comps/widgets/team_comps_triangle.dart
+++ b/lib/team_comps/widgets/team_comps_triangle.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/app_router/routes.dart';

--- a/lib/team_comps_detail/view/team_comps_detail_page.dart
+++ b/lib/team_comps_detail/view/team_comps_detail_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat/l10n/l10n.dart';
 import 'package:vsdat/team_comps_detail/team_comps_detail.dart';

--- a/packages/agents_repository/pubspec.yaml
+++ b/packages/agents_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.13.0-0
+  sdk: ^3.14.0-0
 
 resolution: workspace
 

--- a/packages/formz_inputs/pubspec.yaml
+++ b/packages/formz_inputs/pubspec.yaml
@@ -4,13 +4,13 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.13.0-0
+  sdk: ^3.14.0-0
 
 resolution: workspace
 
 dependencies:
   cross_file: ^0.3.5+4
-  formz: ^0.8.0
+  formz: ^0.8.1
 
 dev_dependencies:
   mocktail: ^1.0.5

--- a/packages/matches_repository/pubspec.yaml
+++ b/packages/matches_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.13.0-0
+  sdk: ^3.14.0-0
 
 resolution: workspace
 

--- a/packages/valorant_agents/pubspec.yaml
+++ b/packages/valorant_agents/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.13.0-0
+  sdk: ^3.14.0-0
 
 resolution: workspace
 

--- a/packages/vsdat_ui/lib/src/extensions/agent_color_extension.dart
+++ b/packages/vsdat_ui/lib/src/extensions/agent_color_extension.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 
 extension AgentColorExtension on Agent {

--- a/packages/vsdat_ui/lib/src/extensions/breakpoint_extension.dart
+++ b/packages/vsdat_ui/lib/src/extensions/breakpoint_extension.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Spacing value of the compact breakpoint according to
 /// the material 3 design spec.

--- a/packages/vsdat_ui/lib/src/extensions/score_color_extension.dart
+++ b/packages/vsdat_ui/lib/src/extensions/score_color_extension.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/extensions/snackbar_extension.dart
+++ b/packages/vsdat_ui/lib/src/extensions/snackbar_extension.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 extension SnackbarContextExtension on BuildContext {
   void showSnackbar(SnackBar snackBar) {

--- a/packages/vsdat_ui/lib/src/styles/themed.dart
+++ b/packages/vsdat_ui/lib/src/styles/themed.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// {@template themed_value}
 /// Helper class that helps to resolve a value based on the current app

--- a/packages/vsdat_ui/lib/src/ternary_plot/counter_triangle_arrow_plot.dart
+++ b/packages/vsdat_ui/lib/src/ternary_plot/counter_triangle_arrow_plot.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/packages/vsdat_ui/lib/src/ternary_plot/styles.dart
+++ b/packages/vsdat_ui/lib/src/ternary_plot/styles.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/theme/vsdat_theme.dart
+++ b/packages/vsdat_ui/lib/src/theme/vsdat_theme.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// {@template vsdat_theme}
 /// Create ThemeData for VSDAT

--- a/packages/vsdat_ui/lib/src/widgets/_interactive_viewer_transform.dart
+++ b/packages/vsdat_ui/lib/src/widgets/_interactive_viewer_transform.dart
@@ -12,8 +12,8 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide InteractiveViewer;
 import 'package:flutter/physics.dart';
+import 'package:material_ui/material_ui.dart' hide InteractiveViewer;
 import 'package:vector_math/vector_math_64.dart' show Matrix4, Quad, Vector3;
 
 /// A widget that enables pan and zoom interactions with its child.

--- a/packages/vsdat_ui/lib/src/widgets/agent_icon.dart
+++ b/packages/vsdat_ui/lib/src/widgets/agent_icon.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/agent_indicator.dart
+++ b/packages/vsdat_ui/lib/src/widgets/agent_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/agent_point_breakdown.dart
+++ b/packages/vsdat_ui/lib/src/widgets/agent_point_breakdown.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/agent_select.dart
+++ b/packages/vsdat_ui/lib/src/widgets/agent_select.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/circle_indicator.dart
+++ b/packages/vsdat_ui/lib/src/widgets/circle_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 
 class CircleIndicator extends StatelessWidget {

--- a/packages/vsdat_ui/lib/src/widgets/colored_acm.dart
+++ b/packages/vsdat_ui/lib/src/widgets/colored_acm.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/drawer_header_text.dart
+++ b/packages/vsdat_ui/lib/src/widgets/drawer_header_text.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class DrawerHeaderText extends StatelessWidget {
   const DrawerHeaderText(this.label, {super.key});

--- a/packages/vsdat_ui/lib/src/widgets/filter_chips_wrap.dart
+++ b/packages/vsdat_ui/lib/src/widgets/filter_chips_wrap.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class FilterChipsWrap<T> extends StatelessWidget {
   const FilterChipsWrap({

--- a/packages/vsdat_ui/lib/src/widgets/interactive_chart_viewer.dart
+++ b/packages/vsdat_ui/lib/src/widgets/interactive_chart_viewer.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart' hide InteractiveViewer;
+import 'package:material_ui/material_ui.dart' hide InteractiveViewer;
 import 'package:vsdat_ui/src/widgets/_interactive_viewer_transform.dart'
     show InteractiveViewer;
 

--- a/packages/vsdat_ui/lib/src/widgets/labelled_acm.dart
+++ b/packages/vsdat_ui/lib/src/widgets/labelled_acm.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/match_tile.dart
+++ b/packages/vsdat_ui/lib/src/widgets/match_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/matches_list_view.dart
+++ b/packages/vsdat_ui/lib/src/widgets/matches_list_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/responsive_list_view.dart
+++ b/packages/vsdat_ui/lib/src/widgets/responsive_list_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 
 class ResponsiveListView<T> extends StatelessWidget {

--- a/packages/vsdat_ui/lib/src/widgets/responsive_padding.dart
+++ b/packages/vsdat_ui/lib/src/widgets/responsive_padding.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 
 class ResponsivePadding extends StatelessWidget {

--- a/packages/vsdat_ui/lib/src/widgets/roster_select_button.dart
+++ b/packages/vsdat_ui/lib/src/widgets/roster_select_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 typedef RosterChangeCallback = void Function(String rosterName);
 

--- a/packages/vsdat_ui/lib/src/widgets/slider_text_input.dart
+++ b/packages/vsdat_ui/lib/src/widgets/slider_text_input.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// {@template slider_text_input}
 /// A Widget to input integer values using a linked Slider and a TextField.

--- a/packages/vsdat_ui/lib/src/widgets/style_triangle.dart
+++ b/packages/vsdat_ui/lib/src/widgets/style_triangle.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/style_type_icon.dart
+++ b/packages/vsdat_ui/lib/src/widgets/style_type_icon.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:valorant_agents/valorant_agents.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';

--- a/packages/vsdat_ui/lib/src/widgets/ternary_plot_hover_info.dart
+++ b/packages/vsdat_ui/lib/src/widgets/ternary_plot_hover_info.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:ternary_plot/ternary_plot.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 

--- a/packages/vsdat_ui/lib/src/widgets/width_constrained_box.dart
+++ b/packages/vsdat_ui/lib/src/widgets/width_constrained_box.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class WidthConstrainedBox extends StatelessWidget {
   const WidthConstrainedBox({

--- a/packages/vsdat_ui/pubspec.yaml
+++ b/packages/vsdat_ui/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_portal: ^1.1.4
+  material_ui: ^0.0.3+1
   ternary_plot:
     git: https://github.com/ShakyaCsun/ternary_plot.git
   valorant_agents:

--- a/packages/vsdat_ui/pubspec.yaml
+++ b/packages/vsdat_ui/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.13.0-0
-  flutter: '>=3.47.0-0'
+  sdk: ^3.14.0-0
+  flutter: '>=3.48.0-0'
 
 resolution: workspace
 

--- a/packages/vsdat_ui/test/styles/val_colors_test.dart
+++ b/packages/vsdat_ui/test/styles/val_colors_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vsdat_ui/vsdat_ui.dart';
 
 void main() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -402,10 +402,10 @@ packages:
     dependency: "direct main"
     description:
       name: formz
-      sha256: "382c7be452ff76833f9efa0b2333fec3a576393f6d2c7801725bed502f3d40c3"
+      sha256: e8dc647e0d5922bcd7cbfd95ec3a320d8a9015b0902c7c8e69eaafb753041ce7
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.8.1"
   freezed:
     dependency: "direct dev"
     description:
@@ -442,10 +442,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "55973bf1b27790489f8710ea615fe939f911ddcc5986fe97305e4fc19fa29ee9"
+      sha256: d7a3576cb312649eaa51f2356450aed686085fb58fcdebda5b359aa951eef7ea
       url: "https://pub.dev"
     source: hosted
-    version: "17.4.0"
+    version: "17.5.0"
   go_router_builder:
     dependency: "direct dev"
     description:
@@ -1109,5 +1109,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.13.0-0 <4.0.0"
-  flutter: ">=3.47.0-0"
+  dart: ">=3.14.0-0 <4.0.0"
+  flutter: ">=3.48.0-0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,6 +218,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: "58191e8c198d274d299b4a92e5fa9bf1abf1d870067cf064b67f2217957aefe9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3+1"
   dart_style:
     dependency: transitive
     description:
@@ -598,6 +606,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: ba53669b1fac77c3481ffba90833e2d847f2510faba8781a1bbe11e8f2c71a94
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3+1"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   logging: ^1.3.0
   matches_repository:
     path: ./packages/matches_repository
+  material_ui: ^0.0.3+1
   riverpod_annotation: ^4.0.6
   ternary_plot:
     git: https://github.com/ShakyaCsun/ternary_plot.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.13.0-0
-  flutter: '>=3.47.0-0'
+  sdk: ^3.14.0-0
+  flutter: '>=3.48.0-0'
 
 workspace:
   - packages/agents_repository
@@ -29,11 +29,11 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^3.4.2
   flutter_svg: ^2.3.0
-  formz: ^0.8.0
+  formz: ^0.8.1
   formz_inputs:
     path: ./packages/formz_inputs
   freezed_annotation: ^3.1.0
-  go_router: ^17.4.0
+  go_router: ^17.5.0
   intl: ^0.20.3
   logging: ^1.3.0
   matches_repository:


### PR DESCRIPTION
## Status

**READY**

## Description

- Upgrade minimum Flutter version to latest beta 3.48.0-0.1.pre
- Set minimum Dart version to 3.14.0-0
- Run `flutter pub upgrade --tighten`
- [android] Upgrade to Gradle 9.7.0
- Perform early migration to `material_ui` package related to [Flutter issue #184093](https://redirect.github.com/flutter/flutter/issues/184093)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
